### PR TITLE
Decoupling thermostat mass (Q) and temperature (T) for stability purposes.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,7 +130,7 @@ int main(int argc, const char *argv[]) {
              "Discretization parameter 2")
             ("chain_length_real,C", value<unsigned int>(&chain_length_real)->default_value(5),
              "Number of thermostat particles in the Nose-Hoover chain (plus 1).")
-            ("thermostatMass,Q", value<double>(&Q)->default_value(10*T),
+            ("thermostatMass,Q", value<double>(&Q)->default_value(.01),
              "Mass of the thermostat (higher means less strongly coupled).")
                 // Annealing Parameters:
             ("annealFlag,a", value<char>(&mdremote.anneal)->default_value('y'),
@@ -172,8 +172,7 @@ int main(int argc, const char *argv[]) {
 
     disc1 = 3;                                          //  Discretization parameters (h, k).
     alpha = 1.0;                                        //  Fractional charge occupancy.
-    if (chain_length_real == 1) Q = 0;                  //  Reduced mass of the thermostat particle(s).
-    else Q = 10 * T;        // Thermostat mass must be set to zero for safety if (C = 1).
+    if (chain_length_real == 1) Q = 0;                  //  Reduced mass of the thermostat particle(s)
 
     mdremote.QAnnealFac =
             1.00 + (mdremote.TAnnealFac / 10.0);        // Maintain previous scaling, same as before (fQ = 2) if fT = 10.


### PR DESCRIPTION
The thermostat mass was previously scaling as (Q = 10T).  However, coupling of the thermostat is such that the higher the mass, the tighter the coupling.  We previously used NVT to prevent the system from getting too hot such that things were unstable (e.g. in the initial PNAS paper it was T = 0.0001, which is much lower than the natural NVE temperature of most of these systems).  Even for Q = 10T = 0.001, it had trouble regulating the temperature well early on in the simulations, but this didn't lead to instability.  Now, a large number of the jobs with patterns diverge numerically during this burst phase where the temperature is not well regulated.  I suspect lowering the temperature but increasing the thermostat mass (to increase ability to regulate the temperature during that burst phase) will help.

Either way, this will allow users to independently specify the thermostat mass (boost parameter Q) rather than having it coupled to the temperature.