### PR TITLE
Adding soft volume constraint.

### DIFF
--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -780,8 +780,8 @@ void INTERFACE::compute_energy(int num, const double scalefactor) {
 
     double VolTEnergy = 0;
     VolTEnergy = (sigma_v * ((total_volume - ref_volume) * (total_volume - ref_volume))); // Quadratic in volume difference from sphere.
-    //VolTEnergy = (sigma_v * (total_volume  * total_volume / ref_volume));		// Quadratic in absolute volume.
-    //VolTEnergy = (sigma_v * total_volume);    // Linear in absolute area.
+    //VolTEnergy = (sigma_v * (total_volume  * total_volume));		// Quadratic in absolute volume.
+    //VolTEnergy = (sigma_v * total_volume);    // Linear in absolute volume.
     penergy += VolTEnergy; // Output below to occur as last column.
 
     // Initialize, compute, and output the net {LJ, ES} energies:

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -778,6 +778,12 @@ void INTERFACE::compute_energy(int num, const double scalefactor) {
     if (world.rank() == 0)
         output << TEnergy << " ";
 
+    double VolTEnergy = 0;
+    VolTEnergy = (sigma_v * ((total_volume - ref_volume) * (total_volume - ref_volume))); // Quadratic in volume difference from sphere.
+    //VolTEnergy = (sigma_v * (total_volume  * total_volume / ref_volume));		// Quadratic in absolute volume.
+    //VolTEnergy = (sigma_v * total_volume);    // Linear in absolute area.
+    penergy += VolTEnergy; // Output below to occur as last column.
+
     // Initialize, compute, and output the net {LJ, ES} energies:
     //Common MPI Message objects
     vector<double> energyLJ(sizFVec, 0.0);
@@ -800,11 +806,8 @@ void INTERFACE::compute_energy(int num, const double scalefactor) {
     }
 
     for (i = lowerBound; i <= upperBound; i++) {
-
         lj_total += energyLJ[i-lowerBound];
         es_total += energyES[i-lowerBound];
-
-
     }
 
     //MPI Operations
@@ -823,8 +826,6 @@ void INTERFACE::compute_energy(int num, const double scalefactor) {
     }
         penergy += lj_totalT + es_totalT;
 
-
-
     /*
     if (world.rank() == 0) {
         if (num == 0)
@@ -837,7 +838,10 @@ void INTERFACE::compute_energy(int num, const double scalefactor) {
 
     //penergy += lj_total + es_total;
     if (world.rank() == 0)
-        output << lj_totalT << " " << es_totalT << endl;
+        output << lj_totalT << " " << es_totalT << " ";
+
+    if (world.rank() == 0)
+        output << VolTEnergy << endl;
 
 /*	// line tension energy
 

--- a/src/interface.h
+++ b/src/interface.h
@@ -94,6 +94,9 @@ public:
     double sconstant;
     double sigma_a;            // Strength of the surface tension penalty ((kB T) / L^2).
 
+    // soft-volume constraint parameter:
+    double sigma_v;
+
     EDGE *edge_between(VERTEX *, VERTEX *);
 
     // ### Geometric operations: ###

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,7 +283,7 @@ int main(int argc, const char *argv[]) {
         cout << "Stretching constant: " << boundary.sconstant << endl;
         cout << "Surface Tension constant: " << (boundary.sigma_a / dynePerCm_Scalefactor) << endl;
         //cout << "Volume Tension constant: " << (boundary.sigma_v / (pow(10, -7)*unit_radius_sphere*dynePerCm_Scalefactor)) << endl;
-        cout << "Volume Tension constant: " << (boundary.sigma_v / (pow(10,24) * (pow(10, -28)*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*dynePerCm_Scalefactor)))<< endl;
+        cout << "Volume Tension constant: " << (boundary.sigma_v / dynePerUmFifth_Scalefactor)<< endl;
         cout << "Unstretched edge length: " << boundary.avg_edge_length
              << endl; // NB uncommented & replaced the output value.
         cout << "LJ strength: " << boundary.elj << endl;
@@ -330,8 +330,7 @@ int main(int argc, const char *argv[]) {
         list_out << "Young's Modulus (2D): " << youngsModulus << endl;
         list_out << "Stretching constant: " << boundary.sconstant << endl;
         list_out << "Surface Tension constant: " << (boundary.sigma_a / dynePerCm_Scalefactor) << endl;
-        //list_out << "Volume Tension constant: " << (boundary.sigma_v / ((pow(10,8) * pow(10, -7)*unit_radius_sphere*dynePerCm_Scalefactor))) << endl;
-        list_out << "Volume Tension constant: " << (boundary.sigma_v / (pow(10,24) * (pow(10, -28)*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*dynePerCm_Scalefactor))) << endl;
+        list_out << "Volume Tension constant: " << (boundary.sigma_v / dynePerUmFifth_Scalefactor) << endl;
         list_out << "LJ strength: " << boundary.elj << endl;
         list_out << "LJ distance cutoff: " << boundary.lj_length << endl;
         list_out << "Rigid geometric constraint: " << geomConstraint << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,8 +110,8 @@ int main(int argc, const char *argv[]) {
              "Salt concentration (Molar).")
             ("tensSigma,t", value<double>(&boundary.sigma_a)->default_value(3),
              "Surface tension constant (dynes/cm).")
-            ("volTensSigma,v", value<double>(&boundary.sigma_v)->default_value(1000000),
-             "Volume tension constant (dynes/micrometer^5).")
+            ("volTensSigma,v", value<double>(&boundary.sigma_v)->default_value(1),
+             "Volume tension constant (atm/nm^3).")
             ("bending,b", value<double>(&boundary.bkappa)->default_value(30),
              "The bending modulus of the particle (kB*T).")
             ("Stretching,s", value<double>(&boundary.sconstant)->default_value(100),
@@ -168,8 +168,10 @@ int main(int argc, const char *argv[]) {
     // The dimensionless form of the tension factors are a function of radius:
     double dynePerCm_Scalefactor = pow(10,-14)*(pow(unit_radius_sphere, 2)/unitenergy);
     boundary.sigma_a = (dynePerCm_Scalefactor * boundary.sigma_a);    // Coefficient is 1 (dyne/cm) in (kB T_room/(R0 nm^2)).
-    double dynePerUmFifth_Scalefactor = pow(10,-4)*pow(10,-18)*(pow(unit_radius_sphere, 6)/unitenergy);
-    boundary.sigma_v = (dynePerUmFifth_Scalefactor * boundary.sigma_v);
+    //double dynePerUmFifth_Scalefactor = pow(10,-4)*pow(10,-18)*(pow(unit_radius_sphere, 6)/unitenergy);
+    //boundary.sigma_v = (dynePerUmFifth_Scalefactor * boundary.sigma_v);
+    double atmPerNmThird_Scalefactor = (1.01325 * pow(10,5)) * pow(10,-27) * (pow(unit_radius_sphere, 6) / (unitenergy * pow(10, -7)));
+    boundary.sigma_v = atmPerNmThird_Scalefactor * boundary.sigma_v;
 
     // The scale factor for electrostatic interactions is a function of radius:
     const double scalefactor = epsilon_water * lB_water / unit_radius_sphere;
@@ -241,7 +243,6 @@ int main(int argc, const char *argv[]) {
     // NB added following lines to load off-file (does not warn if the file is not found, yet):
     if (offFlag == 'y') boundary.load_configuration("380000.off");
 
-
     int numOfNodes = world.size();
     if (world.rank() == 0) {
 #pragma omp parallel default(shared)
@@ -282,8 +283,7 @@ int main(int argc, const char *argv[]) {
         cout << "Young's Modulus (2D): " << youngsModulus << endl;
         cout << "Stretching constant: " << boundary.sconstant << endl;
         cout << "Surface Tension constant: " << (boundary.sigma_a / dynePerCm_Scalefactor) << endl;
-        //cout << "Volume Tension constant: " << (boundary.sigma_v / (pow(10, -7)*unit_radius_sphere*dynePerCm_Scalefactor)) << endl;
-        cout << "Volume Tension constant: " << (boundary.sigma_v / dynePerUmFifth_Scalefactor)<< endl;
+        cout << "Volume Tension constant: " << (boundary.sigma_v / atmPerNmThird_Scalefactor)<< endl;
         cout << "Unstretched edge length: " << boundary.avg_edge_length
              << endl; // NB uncommented & replaced the output value.
         cout << "LJ strength: " << boundary.elj << endl;
@@ -330,7 +330,7 @@ int main(int argc, const char *argv[]) {
         list_out << "Young's Modulus (2D): " << youngsModulus << endl;
         list_out << "Stretching constant: " << boundary.sconstant << endl;
         list_out << "Surface Tension constant: " << (boundary.sigma_a / dynePerCm_Scalefactor) << endl;
-        list_out << "Volume Tension constant: " << (boundary.sigma_v / dynePerUmFifth_Scalefactor) << endl;
+        list_out << "Volume Tension constant: " << (boundary.sigma_v / atmPerNmThird_Scalefactor) << endl;
         list_out << "LJ strength: " << boundary.elj << endl;
         list_out << "LJ distance cutoff: " << boundary.lj_length << endl;
         list_out << "Rigid geometric constraint: " << geomConstraint << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,8 +110,8 @@ int main(int argc, const char *argv[]) {
              "Salt concentration (Molar).")
             ("tensSigma,t", value<double>(&boundary.sigma_a)->default_value(3),
              "Surface tension constant (dynes/cm).")
-            ("volTensSigma,v", value<double>(&boundary.sigma_v)->default_value(0),
-             "Volume tension constant (dynes/micrometer^2).")
+            ("volTensSigma,v", value<double>(&boundary.sigma_v)->default_value(100),
+             "Volume tension constant (dynes/micrometer^5).")
             ("bending,b", value<double>(&boundary.bkappa)->default_value(30),
              "The bending modulus of the particle (kB*T).")
             ("Stretching,s", value<double>(&boundary.sconstant)->default_value(100),
@@ -165,10 +165,12 @@ int main(int argc, const char *argv[]) {
     // Compute the 2D Young's Modulus (in kB*T/nm^2) from the reduced stretching constant specified as input:
     youngsModulus = boundary.sconstant / (unit_radius_sphere * unit_radius_sphere);  // For information purposes only.
 
-    // The dimensionless form of the surface tension factor (sigma) is a function of radius:
+    // The dimensionless form of the tension factors are a function of radius:
     double dynePerCm_Scalefactor = pow(10,-14)*unit_radius_sphere*unit_radius_sphere/unitenergy;
     boundary.sigma_a = (dynePerCm_Scalefactor * boundary.sigma_a);    // Coefficient is 1 (dyne/cm) in (kB T_room/(R0 nm^2)).
-    boundary.sigma_v = (pow(10,8) * (pow(10, -7)*unit_radius_sphere*dynePerCm_Scalefactor) * boundary.sigma_v);
+    //boundary.sigma_v = (pow(10,8) * (pow(10, -7)*unit_radius_sphere*dynePerCm_Scalefactor) * boundary.sigma_v);
+        // If the constraint is linear, this has units of dynPerMicrometer^2 correctly.
+    boundary.sigma_v = (pow(10,24) * (pow(10, -28)*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*dynePerCm_Scalefactor) * boundary.sigma_v);
 
     // The scale factor for electrostatic interactions is a function of radius:
     const double scalefactor = epsilon_water * lB_water / unit_radius_sphere;
@@ -281,7 +283,8 @@ int main(int argc, const char *argv[]) {
         cout << "Young's Modulus (2D): " << youngsModulus << endl;
         cout << "Stretching constant: " << boundary.sconstant << endl;
         cout << "Surface Tension constant: " << (boundary.sigma_a / dynePerCm_Scalefactor) << endl;
-        cout << "Volume Tension constant: " << (boundary.sigma_v / (pow(10, -7)*unit_radius_sphere*dynePerCm_Scalefactor)) << endl;
+        //cout << "Volume Tension constant: " << (boundary.sigma_v / (pow(10, -7)*unit_radius_sphere*dynePerCm_Scalefactor)) << endl;
+        cout << "Volume Tension constant: " << (boundary.sigma_v / (pow(10,24) * (pow(10, -28)*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*dynePerCm_Scalefactor)))<< endl;
         cout << "Unstretched edge length: " << boundary.avg_edge_length
              << endl; // NB uncommented & replaced the output value.
         cout << "LJ strength: " << boundary.elj << endl;
@@ -328,7 +331,8 @@ int main(int argc, const char *argv[]) {
         list_out << "Young's Modulus (2D): " << youngsModulus << endl;
         list_out << "Stretching constant: " << boundary.sconstant << endl;
         list_out << "Surface Tension constant: " << (boundary.sigma_a / dynePerCm_Scalefactor) << endl;
-        list_out << "Volume Tension constant: " << (boundary.sigma_v / (pow(10, -7)*unit_radius_sphere*dynePerCm_Scalefactor)) << endl;
+        //list_out << "Volume Tension constant: " << (boundary.sigma_v / ((pow(10,8) * pow(10, -7)*unit_radius_sphere*dynePerCm_Scalefactor))) << endl;
+        list_out << "Volume Tension constant: " << (boundary.sigma_v / (pow(10,24) * (pow(10, -28)*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*dynePerCm_Scalefactor))) << endl;
         list_out << "LJ strength: " << boundary.elj << endl;
         list_out << "LJ distance cutoff: " << boundary.lj_length << endl;
         list_out << "Rigid geometric constraint: " << geomConstraint << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,13 +110,13 @@ int main(int argc, const char *argv[]) {
              "Salt concentration (Molar).")
             ("tensSigma,t", value<double>(&boundary.sigma_a)->default_value(3),
              "Surface tension constant (dynes/cm).")
-            ("volTensSigma,v", value<double>(&boundary.sigma_v)->default_value(100),
+            ("volTensSigma,v", value<double>(&boundary.sigma_v)->default_value(1000000),
              "Volume tension constant (dynes/micrometer^5).")
             ("bending,b", value<double>(&boundary.bkappa)->default_value(30),
              "The bending modulus of the particle (kB*T).")
             ("Stretching,s", value<double>(&boundary.sconstant)->default_value(100),
              "Reduced stretching modulus of the particle (kB*T/R0^2).")
-                // Physical Parameters patterned(Janus & Striped) particles:
+                // Physical Parameters for patterned (Janus & Striped) particles:
             ("numPatches,N", value<int>(&numPatches)->default_value(1),
              "The number of distinct charge patches (of tunable size if N = 2)")
             ("fracChargePatch,p", value<double>(&fracChargedPatch)->default_value(0.5),
@@ -166,11 +166,10 @@ int main(int argc, const char *argv[]) {
     youngsModulus = boundary.sconstant / (unit_radius_sphere * unit_radius_sphere);  // For information purposes only.
 
     // The dimensionless form of the tension factors are a function of radius:
-    double dynePerCm_Scalefactor = pow(10,-14)*unit_radius_sphere*unit_radius_sphere/unitenergy;
+    double dynePerCm_Scalefactor = pow(10,-14)*(pow(unit_radius_sphere, 2)/unitenergy);
     boundary.sigma_a = (dynePerCm_Scalefactor * boundary.sigma_a);    // Coefficient is 1 (dyne/cm) in (kB T_room/(R0 nm^2)).
-    //boundary.sigma_v = (pow(10,8) * (pow(10, -7)*unit_radius_sphere*dynePerCm_Scalefactor) * boundary.sigma_v);
-        // If the constraint is linear, this has units of dynPerMicrometer^2 correctly.
-    boundary.sigma_v = (pow(10,24) * (pow(10, -28)*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*unit_radius_sphere*dynePerCm_Scalefactor) * boundary.sigma_v);
+    double dynePerUmFifth_Scalefactor = pow(10,-4)*pow(10,-18)*(pow(unit_radius_sphere, 6)/unitenergy);
+    boundary.sigma_v = (dynePerUmFifth_Scalefactor * boundary.sigma_v);
 
     // The scale factor for electrostatic interactions is a function of radius:
     const double scalefactor = epsilon_water * lB_water / unit_radius_sphere;

--- a/src/newforces.cpp
+++ b/src/newforces.cpp
@@ -51,10 +51,11 @@ void force_calculation_init(INTERFACE &boundary, const double scalefactor) {
         boundary.V[i].forvec += boundary.V[i].sforce;
     }
     // (2017.09.17 NB added.) Contribute initial tension forces:
-    for (i = 0; i <
-                             boundary.V.size(); i++) {   // Re-calculation of the numerical geometric gradients not required as positions haven't changed from above.
+    for (i = 0; i < boundary.V.size(); i++) {   // Re-calculation of the numerical geometric gradients not required as positions haven't changed from above.
         boundary.V[i].tension_forces(&boundary);
         boundary.V[i].forvec += boundary.V[i].TForce;
+        boundary.V[i].volume_tension_forces(&boundary);
+        boundary.V[i].forvec += boundary.V[i].VolTForce;
     }
 }
 
@@ -116,11 +117,11 @@ void force_calculation(INTERFACE &boundary, const double scalefactor) {
         boundary.V[i].stretching_forces(&boundary);
         //boundary.V[i].forvec += boundary.V[i].sforce;
     }
-    // Surface tension forces (2017.09.17 NB added):
+    // Surface & volume tension forces (2017.09.17, 2019.08.16 NB added):
     for (i = 0; i < boundary.V.size(); i++)
     {   // Recalculation of negated gradients already handled above.
         boundary.V[i].tension_forces(&boundary);
-        //boundary.V[i].forvec += boundary.V[i].TForce;
+        boundary.V[i].volume_tension_forces(&boundary);
     }
 
     //forvec broadcasting using all gather = gather + broadcast
@@ -132,7 +133,7 @@ void force_calculation(INTERFACE &boundary, const double scalefactor) {
     }
 
     for (i = 0; i < boundary.V.size(); i++)
-        boundary.V[i].forvec = forvecGather[i] + boundary.V[i].bforce + boundary.V[i].sforce+ boundary.V[i].TForce;
+        boundary.V[i].forvec = forvecGather[i] + boundary.V[i].bforce + boundary.V[i].sforce + boundary.V[i].TForce + boundary.V[i].VolTForce;
 
     forvec.clear();
     forvecGather.clear();

--- a/src/newmd.cpp
+++ b/src/newmd.cpp
@@ -53,6 +53,7 @@ void md_interface(INTERFACE &boundary, vector<THERMOSTAT> &real_bath, CONTROL &c
         SHAKE_for_area(boundary, cpmdremote, constraintForm);
         RATTLE_for_area(boundary, constraintForm);
     }
+    else cout << endl << "No rigid geometric constraint will be enforced, soft constraints only." << endl << endl;
 
     // Recompute the same quantities as above, assign post-constraint variables for comparison:
     long double vertex_ke = vertex_kinetic_energy(boundary.V);

--- a/src/vertex.cpp
+++ b/src/vertex.cpp
@@ -77,7 +77,7 @@ void VERTEX::tension_forces(INTERFACE* boundary)
 void VERTEX::volume_tension_forces(INTERFACE* boundary)
 {   //  The net volume tension force on a vertex:
     VolTForce = ((2.0 * boundary->sigma_v * (boundary->total_volume - boundary->ref_volume)) ^ neg_GradVi);  // Quadratic volume difference from sphere.
-    //VolTForce = (2.0 * boundary->sigma_v * (boundary->total_volume - boundary->ref_volume) ^ neg_GradVi);          // Quadratic in absolute area.
+    //VolTForce = (2.0 * boundary->sigma_v * (boundary->total_volume) ^ neg_GradVi);          // Quadratic in absolute volume.
     //VolTForce = (boundary->sigma_v ^ neg_GradVi); // Linear in absolute volume.
 }
 

--- a/src/vertex.cpp
+++ b/src/vertex.cpp
@@ -67,10 +67,18 @@ void VERTEX::stretching_forces(INTERFACE* boundary)
 // (2017.09.17 NB added.)  Compute the force on a given vertex due to the surface tension energy penalty:
 void VERTEX::tension_forces(INTERFACE* boundary)
 {
-  //  The net surface tension force on a vertex is (sigma_a) * neg_GradAi:
-  //TForce = ((2.0 * boundary->sigma_a * ((boundary->total_Area_Vertices / boundary->ref_Area_Vertices) - 1)) ^ neg_GradAi);  // Quadratic area difference from sphere.
-  //TForce = ((2.0 * boundary->sigma_a * boundary->total_Area_Vertices / boundary->ref_Area_Vertices) ^ neg_GradAi);          // Quadratic in absolute area.
-  TForce = (boundary->sigma_a ^ neg_GradAi);                                                                                  // Linear in absolute area.
+    //  The net surface tension force on a vertex is (sigma_a) * neg_GradAi:
+    //TForce = ((2.0 * boundary->sigma_a * ((boundary->total_Area_Vertices / boundary->ref_Area_Vertices) - 1)) ^ neg_GradAi);  // Quadratic area difference from sphere.
+    //TForce = ((2.0 * boundary->sigma_a * boundary->total_Area_Vertices / boundary->ref_Area_Vertices) ^ neg_GradAi);          // Quadratic in absolute area.
+    TForce = (boundary->sigma_a ^ neg_GradAi);                                                                                  // Linear in absolute area.
+}
+
+// Compute the force on a given vertex due to the volume tension energy penalty:
+void VERTEX::volume_tension_forces(INTERFACE* boundary)
+{   //  The net volume tension force on a vertex:
+    VolTForce = ((2.0 * boundary->sigma_v * (boundary->total_volume - boundary->ref_volume)) ^ neg_GradVi);  // Quadratic volume difference from sphere.
+    //VolTForce = (2.0 * boundary->sigma_v * (boundary->total_volume - boundary->ref_volume) ^ neg_GradVi);          // Quadratic in absolute area.
+    //VolTForce = (boundary->sigma_v ^ neg_GradVi); // Linear in absolute volume.
 }
 
 // ### Unused functions: ###

--- a/src/vertex.h
+++ b/src/vertex.h
@@ -40,6 +40,7 @@ private:
         ar & bforce;
         ar & sforce;
         ar & TForce;
+        ar & VolTForce; // NB added
         ar & neg_GradVi;
         ar & neg_GradAi;
         ar & neg_GradConi;
@@ -71,6 +72,7 @@ public:
     VECTOR3D bforce;
     VECTOR3D sforce;
     VECTOR3D TForce;
+    VECTOR3D VolTForce;
 
     VECTOR3D neg_GradVi;      // NB modified.  Precise name for what was previously "dummy_vforce".
     VECTOR3D neg_GradAi;      // NB added.
@@ -88,6 +90,7 @@ public:
     void stretching_forces(INTERFACE *);
 
     void tension_forces(INTERFACE *);           // 2017.09.16 NB added:  Compute the tension forces on a given vertex.
+    void volume_tension_forces(INTERFACE *);    // 2019.08.16 NB added:  Comptue volume tension forces on a given vertex.
 
     //void constraint_forces(INTERFACE*);
     //void volume_constraint_gradient(INTERFACE*);


### PR DESCRIPTION
This adds a soft volume constraint as an alternative to the SHAKE/RATTLE routines used previously.  The default (hard-wired) is to use a soft constraint with a high enough penalty that it is effectively equivalent to the hard constraint.  Switching between them is controlled by the character flag parameter within the code (non-BOOST) labeled "geomConstraint" - if set to "V" this flag will constrain the volume rigidly.

Three forms of the constraint are available:

1. Quadratic in the area difference from sphere (Default - hard-wired)

2.  Quadratic in the absolute area (available internally, non-BOOST)

3.  Linear in the absolute area (available internally, non-BOOST)

The default (hard-wired) is the equivalent to the rigid constraint in the limit of infinite penalty.  The others (2, 3) are commented in the associated energy and force functions and must be switched to internally (non-BOOST).  Note the units and necessary magnitude of the penalty change between formulations (1-3).

The **energy penalty per unit volume^2** may be specified via an additional BOOST parameter ("v").  This is specified in units of (**dyn/micrometer^5**), where (v = 10^6) effectively yields the rigid volume constraint results.  The control simulation of a homogeneously charged disc is below showing the results from a rigid constraint and the soft constraint with this high penalty (v = 10^6).

<img width="854" alt="HomogeneousDiscControl_SoftVolumeConstraint_HighPenalty" src="https://user-images.githubusercontent.com/38959843/63612932-7f768a80-c5ad-11e9-9736-198a3fc13108.PNG">

The README command to test this job is unchanged and is:

time ./np_shape_lab -R 10 -q 600 -c 0.005 -t 1 -b 40 -s 40 -S 25000 -D 4

Again, add " -v XXX" to specify an lower or higher penalty, with (v = 100) nearing effectively rigid.