### PR TITLE
Further optimization of ES force calculation.

### DIFF
--- a/src/functions.h
+++ b/src/functions.h
@@ -27,23 +27,6 @@ void auto_correlation_function();
 // display progress bar (code from the internet)
 void progressBar(double);
 
-// ### Functions useful in computing forces and energies: ###
-
-// computes gradient of green's fn
-inline VECTOR3D Grad(VECTOR3D &vec1, VECTOR3D &vec2) {
-    long double r = (vec1 - vec2).GetMagnitude();
-    long double r3 = r * r * r;
-    return (vec1 - vec2) ^ ((-1.0) / r3);
-}
-
-// computes gradient of normal dot gradient of 1/r
-inline VECTOR3D GradndotGrad(VECTOR3D &vec1, VECTOR3D &vec2, VECTOR3D &normal) {
-    long double r = (vec1 - vec2).GetMagnitude();
-    long double r3 = r * r * r;
-    long double r5 = r3 * r * r;
-    return ((normal ^ (1.0 / r3)) - ((vec1 - vec2) ^ (3 * (normal * (vec1 - vec2)) / r5)));
-}
-
 // ### Functions useful in implementing constraints: ###
 
 // SHAKE to ensure the volume constraint is true:  (2017.09.06 NB added conditional bypass if constraint is true already.)
@@ -221,6 +204,21 @@ void initialize_vertex_velocities_to_zero(vector<VERTEX> &V);
 
 // ### Unused functions: ###
 
+// computes gradient of green's fn
+inline VECTOR3D Grad(VECTOR3D &vec1, VECTOR3D &vec2) {
+    long double r = (vec1 - vec2).GetMagnitude();
+    long double r3 = r * r * r;
+    return (vec1 - vec2) ^ ((-1.0) / r3);
+}
+
+// computes gradient of normal dot gradient of 1/r
+inline VECTOR3D GradndotGrad(VECTOR3D &vec1, VECTOR3D &vec2, VECTOR3D &normal) {
+    long double r = (vec1 - vec2).GetMagnitude();
+    long double r3 = r * r * r;
+    long double r5 = r3 * r * r;
+    return ((normal ^ (1.0 / r3)) - ((vec1 - vec2) ^ (3 * (normal * (vec1 - vec2)) / r5)));
+}
+
 // constraint equation
 inline long double constraint(vector<VERTEX> &s, INTERFACE &dsphere) {
 //   return dsphere.total_induced_charge(s) - dsphere.total_charge_inside(ion) * (1/dsphere.eout - 1/dsphere.ein);
@@ -236,6 +234,7 @@ inline long double dotconstraint(vector<VERTEX> &s) {
 }
 
 //  ### Works in progress: ###
+
 // SHAKE_for_area to ensure the area constraint is true:  (Unfinished, vector issues.)
 inline void SHAKE_for_area(INTERFACE &boundary, CONTROL &mdremote, char constraintForm) {
     double fa = 0;

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -541,7 +541,7 @@ void INTERFACE::assign_external_q_values(double q_strength) {
     char fileName[100];
     int col1;
     double col2;
-    sprintf(fileName, "infiles/Charge_Patterns/Output.txt");
+    sprintf(fileName, "infiles/Charge_Patterns/ChargeNeutral_Janus_3-8_p=0.40.dat");
     ifstream inStream(fileName, ios::in);
     if (!inStream)    // Verify the file could be opened.
     {

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -758,7 +758,7 @@ void INTERFACE::compute_local_energies_by_component() {
     }
 }
 
-// Compute the membrane-wide energies at a given step (num), component-wise {kinetic, BE, SE, TE, LJ, ES} respectively:
+// Compute the membrane-wide energies at a given step (num), component-wise {kinetic, BE, SE, TE, VE, LJ, ES} respectively:
 // This produces the "energy_in_parts" output file and calculates the quantities used in "energy_nanomembrane".
 void INTERFACE::compute_energy(int num, const double scalefactor) {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,7 +120,7 @@ int main(int argc, const char *argv[]) {
              "Specification of rigid geometric constraints, 'V' for volume.")
                  // Physical Parameters for patterned (Janus & Striped) particles:
             ("numPatches,N", value<int>(&numPatches)->default_value(1),
-             "The number of distinct charge patches (of tunable size if N = 2)")
+             "The number of distinct charge patches (of tunable size if N = 2).")
             ("fracChargePatch,p", value<double>(&fracChargedPatch)->default_value(0.5),
              "Surface area fraction of the patch (if N = 2, otherwise irrelevant).")
                  // Virtual Parameters:

--- a/src/newenergies.cpp
+++ b/src/newenergies.cpp
@@ -18,6 +18,6 @@ double energy_lj_vertex_vertex(VERTEX& v1, VERTEX& v2, double d, double elj)
 
 double energy_es_vertex_vertex(VERTEX& v1, VERTEX& v2, double em, double inv_kappa, const double scalefactor)
 {
-//   return(scalefactor * v1.q * v2.q  / (em * (v1.posvec - v2.posvec).GetMagnitude()));
-  return(scalefactor * v1.q * v2.q * ( exp(-(1.0/inv_kappa) * (v1.posvec - v2.posvec).GetMagnitude()) ) / (em * (v1.posvec - v2.posvec).GetMagnitude()));
+  double r = (v1.posvec - v2.posvec).GetMagnitude();
+  return(scalefactor * v1.q * v2.q * ( exp(-(1.0/inv_kappa) * r) ) / (em * r));
 }

--- a/src/newforces.cpp
+++ b/src/newforces.cpp
@@ -22,10 +22,7 @@ void force_calculation_init(INTERFACE &boundary, const double scalefactor) {
             VECTOR3D r_vec = boundary.V[i].posvec - boundary.V[j].posvec;
             double r = r_vec.GetMagnitude();
             double r2 = r_vec.GetMagnitudeSquared();
-            double r3 = r * r * r;
             double d2 = boundary.lj_length * boundary.lj_length;
-
-            VECTOR3D grad_vec = r_vec ^ ((-1.0) / r3);
 
             if (r2 < dcut2 * d2) {
                 double r6 = r2 * r2 * r2;
@@ -36,7 +33,7 @@ void force_calculation_init(INTERFACE &boundary, const double scalefactor) {
             }
 
             esforce = ((-scalefactor * boundary.V[i].q * boundary.V[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
-                       (grad_vec + (((-1.0 / boundary.inv_kappa_out) * (1 / r2)) ^ r_vec)));
+                       (r_vec ^ (1/r2)) ^ ((-1.0/r)-(1.0/boundary.inv_kappa_out)));
 
             boundary.V[i].forvec += ljforce + esforce;
         }
@@ -90,10 +87,9 @@ void force_calculation(INTERFACE &boundary, const double scalefactor) {
             VECTOR3D r_vec = boundary.V[i].posvec - boundary.V[j].posvec;
             double r = r_vec.GetMagnitude();
             double r2 = r_vec.GetMagnitudeSquared();
-            double r3 = r * r * r;
             double d2 = boundary.lj_length * boundary.lj_length;
 
-            VECTOR3D grad_vec = r_vec ^ ((-1.0) / r3);
+            //VECTOR3D grad_vec = r_vec ^ ((-1.0) / r3);
 
             if (r2 < dcut2 * d2) {
                 double r6 = r2 * r2 * r2;
@@ -104,7 +100,7 @@ void force_calculation(INTERFACE &boundary, const double scalefactor) {
             }
 
             esforce = ((-scalefactor * boundary.V[i].q * boundary.V[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
-                       (grad_vec + (((-1.0 / boundary.inv_kappa_out) * (1 / r2)) ^ r_vec)));
+                        (r_vec ^ (1/r2)) ^ ((-1.0/r)-(1.0/boundary.inv_kappa_out)));
 
             forvec[i-lowerBound] += ljforce + esforce;
             //boundary.V[i].forvec += ljforce + esforce;

--- a/src/newforces.cpp
+++ b/src/newforces.cpp
@@ -20,8 +20,12 @@ void force_calculation_init(INTERFACE &boundary, const double scalefactor) {
             VECTOR3D ljforce;
             VECTOR3D esforce;
             VECTOR3D r_vec = boundary.V[i].posvec - boundary.V[j].posvec;
+            double r = r_vec.GetMagnitude();
             double r2 = r_vec.GetMagnitudeSquared();
+            double r3 = r * r * r;
             double d2 = boundary.lj_length * boundary.lj_length;
+
+            VECTOR3D grad_vec = r_vec ^ ((-1.0) / r3);
 
             if (r2 < dcut2 * d2) {
                 double r6 = r2 * r2 * r2;
@@ -31,9 +35,8 @@ void force_calculation_init(INTERFACE &boundary, const double scalefactor) {
                 ljforce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
             }
 
-            esforce = ((-scalefactor * boundary.V[i].q * boundary.V[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r_vec.GetMagnitude())) ^
-                       (Grad(boundary.V[i].posvec, boundary.V[j].posvec) +
-                        (((-1.0 / boundary.inv_kappa_out) * (1 / r2)) ^ r_vec)));
+            esforce = ((-scalefactor * boundary.V[i].q * boundary.V[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
+                       (grad_vec + (((-1.0 / boundary.inv_kappa_out) * (1 / r2)) ^ r_vec)));
 
             boundary.V[i].forvec += ljforce + esforce;
         }
@@ -85,8 +88,12 @@ void force_calculation(INTERFACE &boundary, const double scalefactor) {
             VECTOR3D ljforce;
             VECTOR3D esforce;
             VECTOR3D r_vec = boundary.V[i].posvec - boundary.V[j].posvec;
+            double r = r_vec.GetMagnitude();
             double r2 = r_vec.GetMagnitudeSquared();
+            double r3 = r * r * r;
             double d2 = boundary.lj_length * boundary.lj_length;
+
+            VECTOR3D grad_vec = r_vec ^ ((-1.0) / r3);
 
             if (r2 < dcut2 * d2) {
                 double r6 = r2 * r2 * r2;
@@ -96,9 +103,8 @@ void force_calculation(INTERFACE &boundary, const double scalefactor) {
                 ljforce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
             }
 
-            esforce = ((-scalefactor * boundary.V[i].q * boundary.V[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r_vec.GetMagnitude())) ^
-                       (Grad(boundary.V[i].posvec, boundary.V[j].posvec) +
-                        (((-1.0 / boundary.inv_kappa_out) * (1 / r2)) ^ r_vec)));
+            esforce = ((-scalefactor * boundary.V[i].q * boundary.V[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
+                       (grad_vec + (((-1.0 / boundary.inv_kappa_out) * (1 / r2)) ^ r_vec)));
 
             forvec[i-lowerBound] += ljforce + esforce;
             //boundary.V[i].forvec += ljforce + esforce;


### PR DESCRIPTION
In the ES force loop, I removed use of the Grad() function, as it requires separate calculation of "r_vec" and some other things, in favor of using those already computed.

A histogram of how the different steps affect run speed (in steps per second normalized by the base code we have been using).  Different first numbers indicate things done separately (aside from 5, which is a Collective estimate when all things done in the previous pull request are done simultaneously).

<img width="770" alt="Capture" src="https://user-images.githubusercontent.com/38959843/64897258-c7d71480-d650-11e9-8c98-f343cc70dc01.PNG">

So with just the both sets of ES force loop optimizations (Steps 4.1 and 6), there's about a 40% speed-up.  If this scales the same, each job will take around 3.5h or less on the cluster.