### PR TITLE
Adding buckling, removing MPI charge distribution error.

### DIFF
--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -685,7 +685,7 @@ void INTERFACE::compute_local_energies_by_component() {
 
 // Compute the membrane-wide energies at a given step (num), component-wise {kinetic, BE, SE, TE, VE, LJ, ES} respectively:
 // This produces the "energy_in_parts" output file and calculates the quantities used in "energy_nanomembrane".
-void INTERFACE::compute_energy(int num, const double scalefactor) {
+void INTERFACE::compute_energy(int num, const double scalefactor, char bucklingFlag) {
 
     // Initialize & compute net kinetic energy:
     kenergy = 0;
@@ -721,12 +721,20 @@ void INTERFACE::compute_energy(int num, const double scalefactor) {
 
     // Initialize, compute, and output the net stretching energy:
     double senergy = 0;
-    for (unsigned int i = 0; i < E.size(); i++) {
-        double stretched = (E[i].length() - E[i].l0);
-        //     senergy += 0.5 * sconstant * stretched * stretched;
-        senergy += 0.5 * sconstant * stretched * stretched / (E[i].l0 * E[i].l0);
+    if(bucklingFlag == 'n'){
+        for (unsigned int i = 0; i < E.size(); i++) {
+            double stretched = (E[i].length() - E[i].l0);
+            senergy += 0.5 * sconstant * stretched * stretched / (E[i].l0 * E[i].l0);
+        }
+        senergy = senergy * avg_edge_length * avg_edge_length;
     }
-    senergy = senergy * avg_edge_length * avg_edge_length;
+    else {
+        for (unsigned int i = 0; i < E.size(); i++) {
+            //double stretched = (E[i].length() - E[i].l0);
+            double stretched = (E[i].length() - avg_edge_length);
+            senergy += 0.5 * sconstant * stretched * stretched;
+        }
+    }
     penergy += senergy;
     if (world.rank() == 0)
         output << senergy << " ";

--- a/src/interface.h
+++ b/src/interface.h
@@ -129,7 +129,7 @@ public:
     // ###  Energy computation operations: ###
     void compute_local_energies(const double scalefactor);  // (O) Computes the local energetics profiles (creates local_*_E.off files).
     void compute_local_energies_by_component();             // Computes local elastic energy profiles (creates similar files to above).
-    void compute_energy(int, const double scalefactor);     // Commputes energy of the system {KE_, PE_parts, PE_net, Membrane_net}.
+    void compute_energy(int, const double scalefactor, char bucklingFlag);     // Commputes energy of the system {KE_, PE_parts, PE_net, Membrane_net}.
 
     INTERFACE(double _ein = 1,
               double _eout = 1, double _lambda_a = 1, double _lambda_v = 1,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,7 @@ Testing parameters: echo 3 4 100 35 0.0001 300 0.8 0 1 1
 using namespace boost::program_options;
 
 // Declaring function to initiate and propagate the MD (NB added char = constraint flag):
-void md_interface(INTERFACE &, vector<THERMOSTAT> &, CONTROL &, char, char, const double scalefactor);
+void md_interface(INTERFACE &, vector<THERMOSTAT> &, CONTROL &, char, char, char, const double scalefactor);
 
 //MPI boundary parameters
 unsigned int lowerBound;
@@ -92,7 +92,7 @@ int main(int argc, const char *argv[]) {
     double unit_radius_sphere, youngsModulus, q_strength, alpha, conc_out, z_out; // radius (in nm), net charge (if all charged), fractional q-occupancy, salt conc (MOLAR), salt valency
     int numPatches;
     double fracChargedPatch;
-    char randomFlag, offFlag, geomConstraint, constraintForm;
+    char randomFlag, offFlag, geomConstraint, bucklingFlag, constraintForm;
     string externalPattern;
 
     // Control of the dynamics:
@@ -119,6 +119,8 @@ int main(int argc, const char *argv[]) {
              "Reduced stretching modulus of the particle (kB*T/R0^2).")
             ("GeomConstraint,G", value<char>(&geomConstraint)->default_value('N'),
              "Specification of rigid geometric constraints, 'V' for volume.")
+            ("bucklingFlag,B", value<char>(&bucklingFlag)->default_value('n'),
+             "Specification of stretching form, if spontaneous buckling should occur.")
                  // Physical Parameters for patterned (Janus, Striped, Polyhedral) particles:
             ("numPatches,N", value<int>(&numPatches)->default_value(1),
              "The number of distinct charge patches (of tunable size if N = 2).")
@@ -393,7 +395,7 @@ int main(int argc, const char *argv[]) {
         upperBound = boundary.V.size() - 1;
     }
 
-    md_interface(boundary, real_bath, mdremote, geomConstraint, constraintForm, scalefactor);
+    md_interface(boundary, real_bath, mdremote, geomConstraint, bucklingFlag, constraintForm, scalefactor);
     boundary.compute_local_energies(scalefactor);
     boundary.compute_local_energies_by_component();
 

--- a/src/newforces.cpp
+++ b/src/newforces.cpp
@@ -1,7 +1,7 @@
 #include "newforces.h"
 #include "functions.h"
 
-void force_calculation_init(INTERFACE &boundary, const double scalefactor) {
+void force_calculation_init(INTERFACE &boundary, const double scalefactor, char bucklingFlag) {
     unsigned int i=0, j=0;
 
 // Compute constraint gradients: (called 'forces' in prev comment & in SHAKE, RATTLE.)
@@ -48,7 +48,7 @@ void force_calculation_init(INTERFACE &boundary, const double scalefactor) {
         boundary.V[i].forvec += boundary.V[i].bforce;
     // Contribute initial stretching forces (2017.09.17 NB added, initialization implicit):
     for (i = 0; i < boundary.V.size(); i++) {
-        boundary.V[i].stretching_forces(&boundary);
+        boundary.V[i].stretching_forces(&boundary, bucklingFlag);
         boundary.V[i].forvec += boundary.V[i].sforce;
     }
     // (2017.09.17 NB added.) Contribute initial tension forces:
@@ -60,7 +60,7 @@ void force_calculation_init(INTERFACE &boundary, const double scalefactor) {
     }
 }
 
-void force_calculation(INTERFACE &boundary, const double scalefactor) {
+void force_calculation(INTERFACE &boundary, const double scalefactor, char bucklingFlag) {
 
     //Common MPI Message objects
     vector<VECTOR3D> forvec(sizFVec, VECTOR3D(0, 0, 0));
@@ -118,7 +118,7 @@ void force_calculation(INTERFACE &boundary, const double scalefactor) {
     // Update stretching forces:
     for (i = 0; i < boundary.V.size(); i++)
     {
-        boundary.V[i].stretching_forces(&boundary);
+        boundary.V[i].stretching_forces(&boundary, bucklingFlag);
         //boundary.V[i].forvec += boundary.V[i].sforce;
     }
     // Surface & volume tension forces (2017.09.17, 2019.08.16 NB added):

--- a/src/newforces.h
+++ b/src/newforces.h
@@ -3,7 +3,7 @@
 
 #include "vertex.h"
 
-void force_calculation_init(INTERFACE &, const double);	// calculate the forces
-void force_calculation(INTERFACE &, const double);	// calculate the forces
+void force_calculation_init(INTERFACE &, const double, char bucklingFlag);	// calculate the forces
+void force_calculation(INTERFACE &, const double, char bucklingFlag);	// calculate the forces
 
 #endif 

--- a/src/utility.h
+++ b/src/utility.h
@@ -29,6 +29,8 @@ namespace mpi = boost::mpi;
 
 using namespace std;
 
+
+
 // constants
 const double pi = 3.1415926535897932384626433832795028841971693993751;		// Pi, NB added to significant digits
 const double dcut = 1.12246204830937298142;					// Cutoff distance in Lennard-Jones = 2 ^ (1/6)

--- a/src/vertex.cpp
+++ b/src/vertex.cpp
@@ -53,24 +53,39 @@ void VERTEX::compute_neg_VGrads(INTERFACE* boundary/*, char constraintFlag*/)
 }
 
 // Compute the force on a given vertex due to the stretching energy penalty:
-void VERTEX::stretching_forces(INTERFACE* boundary)
+void VERTEX::stretching_forces(INTERFACE* boundary, char bucklingFlag)
 {
   VECTOR3D temp_sforce;       // The stretching force due to one edge on the vertex.
   sforce = VECTOR3D(0,0,0);   // The net stretching force due to all edges on the vertex (iterative sum of the above).
-  
-  for (unsigned int i = 0; i < itsE.size(); i++)
-  {
-    double l = itsE[i]->length();
-    double l0 = itsE[i]->l0;
 
-    temp_sforce = ( (l - l0) / l ) ^ (posvec - itsE[i]->opposite(this)->posvec);
-    
-    temp_sforce = temp_sforce ^ (1.0 / (l0 * l0) );
-    
-    sforce += temp_sforce;
+  if (bucklingFlag == 'n'){
+      for (unsigned int i = 0; i < itsE.size(); i++)
+      {
+          double l = itsE[i]->length();
+          double l0 = itsE[i]->l0;
+
+          temp_sforce = ( (l - l0) / l ) ^ (posvec - itsE[i]->opposite(this)->posvec);
+
+          temp_sforce = temp_sforce ^ (1.0 / (l0 * l0) );
+
+          sforce += temp_sforce;
+      }
+      sforce *= (-1) * boundary->sconstant * boundary->avg_edge_length * boundary->avg_edge_length;
   }
-  
-  sforce *= (-1) * boundary->sconstant * boundary->avg_edge_length * boundary->avg_edge_length;
+  else {
+      for (unsigned int i = 0; i < itsE.size(); i++)
+      {
+          double l = itsE[i]->length();
+          double l0 = boundary->avg_edge_length;
+
+          temp_sforce = ( (l - l0) / l ) ^ (posvec - itsE[i]->opposite(this)->posvec);
+          //temp_sforce = ( (l - l0) / l ) ^ (posvec - itsE[i]->opposite(this)->posvec);
+
+          sforce += temp_sforce;
+      }
+      sforce *= (-1) * boundary->sconstant;
+  }
+
 }
 
 // (2017.09.17 NB added.)  Compute the force on a given vertex due to the surface tension energy penalty:

--- a/src/vertex.h
+++ b/src/vertex.h
@@ -87,7 +87,7 @@ public:
 
     void
     compute_neg_VGrads(INTERFACE */*, char*/); // 2017.09.16 NB added:  Compute given vertex net area & volume gradient.
-    void stretching_forces(INTERFACE *);
+    void stretching_forces(INTERFACE *, char);
 
     void tension_forces(INTERFACE *);           // 2017.09.16 NB added:  Compute the tension forces on a given vertex.
     void volume_tension_forces(INTERFACE *);    // 2019.08.16 NB added:  Comptue volume tension forces on a given vertex.


### PR DESCRIPTION
This adds a buckling flag ("-B") that specifies if spontaneous elasticity-induced buckling should occur based on the form of the stretching energy used between adjacent vertices.  If set to "y", it occurs.  If set to "n" (the default) it does not occur spontaneously as was published in the PNAS and JMCB papers.  The mathematical difference is highlighted below:

![BucklingMath](https://user-images.githubusercontent.com/38959843/66509126-63b53e00-eaa0-11e9-86c7-a93beca65b0f.jpg)

So average edge length throughout the mesh is the single equilibrium length for all pairs, eliminating any dependence on individual initial edge length which otherwise eliminates buckling.  Here is an example of the buckling that occurs if above the buckling transition point (e.g. FvK = 1000):

![3-4_R=10_b=1_s=1000](https://user-images.githubusercontent.com/38959843/66509326-cf97a680-eaa0-11e9-93b7-2e951ac1b356.png)

This also replaces a time-based random seed with a single numerical random seed number (hard-wired, not based on time), as slight differences in the time each processor runs the "time(0)" command will otherwise lead to different charge distributions on each when using MPI - leading to stability issues.  So now the random flag ("-F"), when set to "y", simply uses a single random seed constant between processors to shuffle the charges.  No bulk runs have ever been done with this mistake, it was just introduced amidst other small changes.  Having a single hard-wired random seed is not expected to change results appreciably, as different shuffles lead to only a few kB*T of energy difference (out of several thousand) and even the 12-patch icosahedral systems (with significant uncharged areas) behaves as if it's fairly homogeneous.

This also reverts the annealing protocol temperature decrements to as they were in the JMCB paper, as they were shifted slightly when we removed some warnings in a previous pull.