### PR TITLE
Energy calculations for ions, output.

### DIFF
--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -36,14 +36,14 @@ void initialize_vertex_velocities(vector<VERTEX> &V, vector<THERMOSTAT> &bath) {
     return;
 }
 
-// NB 2017.09.04:  initialize vertex velocities to zero
-void initialize_vertex_velocities_to_zero(vector<VERTEX> &V) {
+// NB 2017.09.04:  initialize vertex/mesh velocities to zero
+void initialize_velocities_to_zero(vector<VERTEX> &V, vector<PARTICLE> &counterions) {
     for (unsigned int i = 0; i < V.size(); i++) {
         V[i].velvec = VECTOR3D(0, 0, 0);
     }
-    //VECTOR3D average_velocity_vector = VECTOR3D(0, 0, 0);
-    //for (unsigned int i = 0; i < V.size(); i++)
-        //V[i].velvec = V[i].velvec - average_velocity_vector;
+    for (unsigned int i = 0; i < counterions.size(); i++) {
+        counterions[i].velvec = VECTOR3D(0, 0, 0);
+    }
 }
 
 // interface movie for VMD

--- a/src/functions.h
+++ b/src/functions.h
@@ -203,7 +203,7 @@ void interface_off(int num, INTERFACE &dsphere);
 void initialize_vertex_velocities(vector<VERTEX> &V, vector<THERMOSTAT> &bath);
 
 // initialize velocities of vertics to be zero
-void initialize_vertex_velocities_to_zero(vector<VERTEX> &V);
+void initialize_velocities_to_zero(vector<VERTEX> &V, vector<PARTICLE> &counterions);
 
 // ### Unused functions: ###
 

--- a/src/interface.h
+++ b/src/interface.h
@@ -39,7 +39,7 @@ private:
         ar & ref_volume;
         ar & ref_Area_Vertices;
         ar & energy;
-        ar & kenergy;
+        ar & netMeshKE;
         ar & penergy;
         ar & lB_out;
         ar & inv_kappa_out;
@@ -72,7 +72,7 @@ public:
     double lambda_a, lambda_v, lambda_l;
     double bkappa;
     double ref_area, ref_volume, ref_Area_Vertices;         // (2017.09.19 NB added ref_Area_Vertices.)
-    double energy, kenergy, penergy;
+    double energy, netMeshKE, netIonKE, penergy;
 
     double lB_out;            // Bjerrum length outside
     double inv_kappa_out;            // debye length outside
@@ -132,7 +132,7 @@ public:
     // ###  Energy computation operations: ###
     void compute_local_energies(const double scalefactor);  // Computes the local energetics profiles (creates local_*_E.off files).
     void compute_local_energies_by_component();             // Computes local elastic energy profiles (creates similar files to above).
-    void compute_energy(int, const double scalefactor, char bucklingFlag);     // Commputes energy of the system {KE_, PE_parts, PE_net, Membrane_net}.
+    void compute_energy(int, vector<PARTICLE> &counterions, const double scalefactor, char bucklingFlag);     // Computes system energy.
 
     INTERFACE(double _ein = 1,
               double _eout = 1, double _lambda_a = 1, double _lambda_v = 1,

--- a/src/mpi_utility.h
+++ b/src/mpi_utility.h
@@ -9,9 +9,13 @@ extern mpi::environment env;
 extern mpi::communicator world;
 
 //MPI boundary parameters
-extern unsigned int lowerBound;
-extern unsigned int upperBound;
-extern unsigned int sizFVec;
-extern unsigned int extraElements;
+extern unsigned int lowerBoundMesh;
+extern unsigned int upperBoundMesh;
+extern int lowerBoundIons;
+extern int upperBoundIons;
+extern unsigned int sizFVecMesh;
+extern int sizFVecIons;
+//extern unsigned int extraElementsMesh;
+//extern unsigned int extraElementsIons;
 
 #endif

--- a/src/newenergies.cpp
+++ b/src/newenergies.cpp
@@ -1,8 +1,9 @@
 #include "newenergies.h"
 
-double energy_lj_vertex_vertex(VERTEX& v1, VERTEX& v2, double d, double elj)
+// Common LJ function for all pairs:
+double energy_lj_pair(VECTOR3D &pos1, VECTOR3D &pos2, double d, double elj)
 {
-  VECTOR3D r_vec = v1.posvec - v2.posvec;
+  VECTOR3D r_vec = pos1 - pos2;
   double r2 = r_vec.GetMagnitudeSquared();
   double d2 = d * d;
   
@@ -16,8 +17,27 @@ double energy_lj_vertex_vertex(VERTEX& v1, VERTEX& v2, double d, double elj)
     return 0;
 }
 
-double energy_es_vertex_vertex(VERTEX& v1, VERTEX& v2, double em, double inv_kappa, const double scalefactor)
+// ### ES Pair-specific functions (overloaded for mesh and particle classes, but entities always referred to as 'vN'):
+    // For vertex-vertex pairs:
+double energy_es_pair(VERTEX &v1, VERTEX &v2, double em, double inv_kappa, const double scalefactor)
 {
   double r = (v1.posvec - v2.posvec).GetMagnitude();
   return(scalefactor * v1.q * v2.q * ( exp(-(1.0/inv_kappa) * r) ) / (em * r));
+}
+    //  For vertex-particle pairs (both permutations, for safety):
+double energy_es_pair(VERTEX &v1, PARTICLE &v2, double em, double inv_kappa, const double scalefactor)
+{
+    double r = (v1.posvec - v2.posvec).GetMagnitude();
+    return(scalefactor * v1.q * v2.q * ( exp(-(1.0/inv_kappa) * r) ) / (em * r));
+}
+double energy_es_pair(PARTICLE &v1, VERTEX &v2, double em, double inv_kappa, const double scalefactor)
+{
+    double r = (v1.posvec - v2.posvec).GetMagnitude();
+    return(scalefactor * v1.q * v2.q * ( exp(-(1.0/inv_kappa) * r) ) / (em * r));
+}
+    // For particle-particle pairs:
+double energy_es_pair(PARTICLE &v1, PARTICLE &v2, double em, double inv_kappa, const double scalefactor)
+{
+    double r = (v1.posvec - v2.posvec).GetMagnitude();
+    return(scalefactor * v1.q * v2.q * ( exp(-(1.0/inv_kappa) * r) ) / (em * r));
 }

--- a/src/newenergies.h
+++ b/src/newenergies.h
@@ -4,15 +4,25 @@
 #include "vertex.h"
 #include "thermostat.h"
 
-// Computes the kinetic energy of the vertices && returns the net kinetic energy for assignment, if desired:
-inline long double vertex_kinetic_energy(vector<VERTEX>& V)
+// Computes the kinetic energy of the vertices & returns the net kinetic energy for assignment, if desired:
+inline long double compute_kinetic_energy(vector<VERTEX>& V)
 {
   for (unsigned int i = 0; i < V.size(); i++)
     V[i].real_kinetic_energy();
   long double kinetic_energy = 0.0;
   for (unsigned int i = 0; i < V.size(); i++)
-    kinetic_energy += V[i].realke;
+    kinetic_energy += V[i].ke;
   return kinetic_energy;
+}
+// Overloads to also compute the KE of the ions & return their net kinetic energy for assignment, if desired:
+inline long double compute_kinetic_energy(vector<PARTICLE>& counterions)
+{
+    for (unsigned int i = 0; i < counterions.size(); i++)
+        counterions[i].real_kinetic_energy();
+    long double kinetic_energy = 0.0;
+    for (unsigned int i = 0; i < counterions.size(); i++)
+        kinetic_energy += counterions[i].ke;
+    return kinetic_energy;
 }
 
 inline double bath_kinetic_energy(vector<THERMOSTAT>& bath)
@@ -35,7 +45,10 @@ inline double bath_potential_energy(vector<THERMOSTAT>& bath)
   return potential_energy;
 }
 
-double energy_lj_vertex_vertex(VERTEX&, VERTEX&, double, double);
-double energy_es_vertex_vertex(VERTEX&, VERTEX&, double, double, const double);
+double energy_lj_pair(VECTOR3D &pos1, VECTOR3D &pos2, double d, double elj);
+double energy_es_pair(VERTEX &v1, VERTEX &v2, double em, double inv_kappa, const double scalefactor);
+double energy_es_pair(VERTEX &v1, PARTICLE &v2, double em, double inv_kappa, const double scalefactor);
+double energy_es_pair(PARTICLE &v1, VERTEX &v2, double em, double inv_kappa, const double scalefactor);
+double energy_es_pair(PARTICLE &v1, PARTICLE &v2, double em, double inv_kappa, const double scalefactor);
 
 #endif

--- a/src/particle.h
+++ b/src/particle.h
@@ -85,9 +85,9 @@ public:
     }
 
     // calculate kinetic energy of a particle
-    void kinetic_energy()
+    void real_kinetic_energy()
     {
-        ke = 0.5 * m * velvec.GetMagnitude() * velvec.GetMagnitude();
+        ke = 0.5 * m * (velvec * velvec);
         return;
     }
 };

--- a/src/vertex.h
+++ b/src/vertex.h
@@ -44,7 +44,7 @@ private:
         ar & neg_GradVi;
         ar & neg_GradAi;
         ar & neg_GradConi;
-        ar & realke;
+        ar & ke;
         ar & r;
         ar & theta;
         ar & phi;
@@ -78,7 +78,7 @@ public:
     VECTOR3D neg_GradAi;      // NB added.
     VECTOR3D neg_GradConi;    // NB added.  Neg constraint gradient on vertex, differs from above if quadratic.
 
-    double realke;
+    double ke;
     double r, theta, phi;            //  Returns the polar coordinates of the vertex.
 
     void compute_area_normal();
@@ -107,9 +107,9 @@ public:
         return;
     }
 
-    // compute REAL kinetic energy
+    // compute kinetic energy
     void real_kinetic_energy() {
-        realke = 0.5 * m * (velvec * velvec);
+        ke = 0.5 * m * (velvec * velvec);
         return;
     }
 


### PR DESCRIPTION
This provides OMP-parallelized energy calculations for the ion components of the code.  It also modifies the outfiles to include those components.  Several functions have been renamed, generalized, and overloaded to apply to both the VERTEX and PARTICLE classes.

All example simulations still match previous results:

<img width="858" alt="NoChange" src="https://user-images.githubusercontent.com/38959843/67598626-fa8a2780-f73b-11e9-9692-8049b74c6506.PNG">

Currently, flagging ions as present ("-I y") will only off-set the electrostatic energy, but does not affect the trajectory as mesh-ion and ion-ion forces are not yet computed, ions have zero initial velocity, and ions don't yet have a thermostat.