### PR TITLE
Final ion propagation (Verlet + parallelized forces/energies).

### DIFF
--- a/src/interface.h
+++ b/src/interface.h
@@ -52,7 +52,7 @@ private:
         ar & rest_volume;
         ar & avg_edge_length;
         ar & elj;
-        ar & lj_length;
+        ar & lj_length_mesh_mesh;
         ar & sconstant;
         ar & sigma_a;
     }
@@ -90,7 +90,8 @@ public:
 
     double avg_edge_length;
     double elj;            // strength of the lj potential
-    double lj_length;
+    double lj_length_mesh_mesh;
+    double lj_length_mesh_ions;
 
     // stretching energy parameters
     double sconstant;
@@ -127,7 +128,7 @@ public:
 
     void assign_external_q_values(double q_strength, string externalPattern);
 
-    void put_counterions(double q_actual, double unit_radius_sphere, double box_radius, vector<PARTICLE> &counterions, int counterion_valency);
+    void put_counterions(double q_actual, double unit_radius_sphere, double ion_diameter, double box_radius, vector<PARTICLE> &counterions, int counterion_valency);
 
     // ###  Energy computation operations: ###
     void compute_local_energies(const double scalefactor);  // Computes the local energetics profiles (creates local_*_E.off files).

--- a/src/newenergies.cpp
+++ b/src/newenergies.cpp
@@ -6,7 +6,6 @@ double energy_lj_pair(VECTOR3D &pos1, VECTOR3D &pos2, double d, double elj)
   VECTOR3D r_vec = pos1 - pos2;
   double r2 = r_vec.GetMagnitudeSquared();
   double d2 = d * d;
-  
   if (r2 < dcut2 * d2)
   {
     double r6 = r2 * r2 * r2;

--- a/src/newforces.cpp
+++ b/src/newforces.cpp
@@ -1,41 +1,115 @@
 #include "newforces.h"
 #include "functions.h"
 
-void force_calculation_init(INTERFACE &boundary, const double scalefactor, char bucklingFlag) {
+void force_calculation_init(INTERFACE &boundary, vector<PARTICLE> &counterions, const double scalefactor, char bucklingFlag) {
     unsigned int i=0, j=0;
 
 // Compute constraint gradients: (called 'forces' in prev comment & in SHAKE, RATTLE.)
     for (i = 0; i < boundary.V.size(); i++)
         boundary.V[i].compute_neg_VGrads(&boundary/*, constraintForm*/);
 
-    // Initialize forces on all vertices (NB added): (Verified they autoset to zero before.)
+    // Initialize forces on all vertices, ions:
     for (i = 0; i < boundary.V.size(); i++)
         boundary.V[i].forvec = VECTOR3D(0, 0, 0);
+    for (i = 0; i < counterions.size(); i++)
+        counterions[i].forvec = VECTOR3D(0, 0, 0);
 
     // Contribute LJ & electrostatics forces (initialization implicit):
     #pragma omp parallel for schedule(dynamic) default(shared) private(i, j)
     for (i = 0; i < boundary.V.size(); i++) {
-        for (j = 0; j < boundary.V.size(); j++) {
+        for (j = 0; j < boundary.V.size(); j++) { // The mesh-mesh component:
             if (i == j) continue;
-            VECTOR3D ljforce;
-            VECTOR3D esforce;
+            VECTOR3D ljForce;
+            VECTOR3D esForce;
             VECTOR3D r_vec = boundary.V[i].posvec - boundary.V[j].posvec;
             double r = r_vec.GetMagnitude();
             double r2 = r_vec.GetMagnitudeSquared();
-            double d2 = boundary.lj_length * boundary.lj_length;
+            double d2 = boundary.lj_length_mesh_mesh * boundary.lj_length_mesh_mesh;
 
             if (r2 < dcut2 * d2) {
                 double r6 = r2 * r2 * r2;
                 double r12 = r6 * r6;
                 double d6 = d2 * d2 * d2;
                 double d12 = d6 * d6;
-                ljforce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
+                ljForce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
             }
 
-            esforce = ((-scalefactor * boundary.V[i].q * boundary.V[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
-                       (r_vec ^ (1/r2)) ^ ((-1.0/r)-(1.0/boundary.inv_kappa_out)));
+            esForce = ((-scalefactor * boundary.V[i].q * boundary.V[j].q / boundary.em) *
+                       (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
+                       (r_vec ^ (1 / r2)) ^ ((-1.0 / r) - (1.0 / boundary.inv_kappa_out)));
 
-            boundary.V[i].forvec += ljforce + esforce;
+            boundary.V[i].forvec += ljForce + esForce;
+        }
+
+        for (j = 0; j < counterions.size(); j++) { // The mesh-ion component (for mesh):
+            VECTOR3D ljForce;
+            VECTOR3D esForce;
+            VECTOR3D r_vec = boundary.V[i].posvec - counterions[j].posvec;
+            double r = r_vec.GetMagnitude();
+            double r2 = r_vec.GetMagnitudeSquared();
+            double d2 = boundary.lj_length_mesh_ions * boundary.lj_length_mesh_ions;
+
+            if (r2 < dcut2 * d2) {
+                double r6 = r2 * r2 * r2;
+                double r12 = r6 * r6;
+                double d6 = d2 * d2 * d2;
+                double d12 = d6 * d6;
+                ljForce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
+            }
+
+            esForce = ((-scalefactor * boundary.V[i].q * counterions[j].q / boundary.em) *
+                       (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
+                       (r_vec ^ (1 / r2)) ^ ((-1.0 / r) - (1.0 / boundary.inv_kappa_out)));
+
+            boundary.V[i].forvec += ljForce + esForce;
+        }
+    }
+    #pragma omp parallel for schedule(dynamic) default(shared) private(i, j)
+    for (i = 0; i < counterions.size(); i++) {
+        for (j = 0; j < counterions.size(); j++) { // The ion-ion component:
+            if (i == j) continue;
+            VECTOR3D ljForce;
+            VECTOR3D esForce;
+            VECTOR3D r_vec = counterions[i].posvec - counterions[j].posvec;
+            double r = r_vec.GetMagnitude();
+            double r2 = r_vec.GetMagnitudeSquared();
+            double d2 = counterions[0].diameter * counterions[0].diameter;
+
+            if (r2 < dcut2 * d2) {
+                double r6 = r2 * r2 * r2;
+                double r12 = r6 * r6;
+                double d6 = d2 * d2 * d2;
+                double d12 = d6 * d6;
+                ljForce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
+            }
+
+            esForce = ((-scalefactor * counterions[i].q * counterions[j].q / boundary.em) *
+                       (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
+                       (r_vec ^ (1 / r2)) ^ ((-1.0 / r) - (1.0 / boundary.inv_kappa_out)));
+
+            counterions[i].forvec += ljForce + esForce;
+        }
+        for (j = 0; j < boundary.V.size(); j++) { // The mesh-ion component:
+            VECTOR3D ljForce;
+            VECTOR3D esForce;
+            VECTOR3D r_vec = counterions[i].posvec - boundary.V[j].posvec;
+            double r = r_vec.GetMagnitude();
+            double r2 = r_vec.GetMagnitudeSquared();
+            double d2 = boundary.lj_length_mesh_ions * boundary.lj_length_mesh_ions;
+
+            if (r2 < dcut2 * d2) {
+                double r6 = r2 * r2 * r2;
+                double r12 = r6 * r6;
+                double d6 = d2 * d2 * d2;
+                double d12 = d6 * d6;
+                ljForce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
+            }
+
+            esForce = ((-scalefactor * counterions[i].q * boundary.V[j].q / boundary.em) *
+                       (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
+                       (r_vec ^ (1 / r2)) ^ ((-1.0 / r) - (1.0 / boundary.inv_kappa_out)));
+
+            counterions[i].forvec += ljForce + esForce;
         }
     }
 
@@ -52,7 +126,7 @@ void force_calculation_init(INTERFACE &boundary, const double scalefactor, char 
         boundary.V[i].forvec += boundary.V[i].sforce;
     }
     // (2017.09.17 NB added.) Contribute initial tension forces:
-    for (i = 0; i < boundary.V.size(); i++) {   // Re-calculation of the numerical geometric gradients not required as positions haven't changed from above.
+    for (i = 0; i < boundary.V.size(); i++) { // Re-calculation of geometric gradients not required as positions haven't changed.
         boundary.V[i].tension_forces(&boundary);
         boundary.V[i].forvec += boundary.V[i].TForce;
         boundary.V[i].volume_tension_forces(&boundary);
@@ -60,12 +134,14 @@ void force_calculation_init(INTERFACE &boundary, const double scalefactor, char 
     }
 }
 
-void force_calculation(INTERFACE &boundary, const double scalefactor, char bucklingFlag) {
+void force_calculation(INTERFACE &boundary, vector<PARTICLE> &counterions, const double scalefactor, char bucklingFlag) {
 
     //Common MPI Message objects
-    vector<VECTOR3D> forvec(sizFVecMesh, VECTOR3D(0, 0, 0));
-    vector<VECTOR3D> forvecGather(boundary.V.size(), VECTOR3D(0, 0, 0));
-    unsigned int i=0, j=0;
+    vector<VECTOR3D> forVecMesh(sizFVecMesh, VECTOR3D(0, 0, 0));
+    vector<VECTOR3D> forVecMeshGather(boundary.V.size(), VECTOR3D(0, 0, 0));
+    vector<VECTOR3D> forVecIons(sizFVecIons, VECTOR3D(0, 0, 0));
+    vector<VECTOR3D> forVecIonsGather(counterions.size(), VECTOR3D(0, 0, 0));
+    int i=0, j=0;
     
 // ### Compute Forces ###
     //boundary.areaGradient.clear();
@@ -73,75 +149,141 @@ void force_calculation(INTERFACE &boundary, const double scalefactor, char buckl
     for (i = 0; i < boundary.V.size(); i++)
         boundary.V[i].compute_neg_VGrads(&boundary/*, constraintForm*/);
 
-    // Update vertex-vertex LJ & electrostatic forces:
-    //i = 0; i < boundary.V.size(); i++
-    //i = lowerBoundMesh; i <= upperBoundMesh; i++
+    // Update LJ & ES forces:
     #pragma omp parallel for schedule(dynamic) default(shared) private(i, j)
     for (i = lowerBoundMesh; i <= upperBoundMesh; i++) {
-        for (j = 0;j < boundary.V.size(); j++) {
-        //for (j = i + 1; j < boundary.V.size(); j++) {
-            // These do not need re-initialized because they are being set each time.
+        // Mesh-mesh component:
+        for (j = 0; j < boundary.V.size(); j++) {
             if (i == j) continue;
-            VECTOR3D ljforce;
-            VECTOR3D esforce;
+            VECTOR3D ljForce;
+            VECTOR3D esForce;
             VECTOR3D r_vec = boundary.V[i].posvec - boundary.V[j].posvec;
             double r = r_vec.GetMagnitude();
             double r2 = r_vec.GetMagnitudeSquared();
-            double d2 = boundary.lj_length * boundary.lj_length;
-
-            //VECTOR3D grad_vec = r_vec ^ ((-1.0) / r3);
+            double d2 = boundary.lj_length_mesh_mesh * boundary.lj_length_mesh_mesh;
 
             if (r2 < dcut2 * d2) {
                 double r6 = r2 * r2 * r2;
                 double r12 = r6 * r6;
                 double d6 = d2 * d2 * d2;
                 double d12 = d6 * d6;
-                ljforce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
+                ljForce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
             }
 
-            esforce = ((-scalefactor * boundary.V[i].q * boundary.V[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
-                        (r_vec ^ (1/r2)) ^ ((-1.0/r)-(1.0/boundary.inv_kappa_out)));
+            esForce = ((-scalefactor * boundary.V[i].q * boundary.V[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
+                       (r_vec ^ (1/r2)) ^ ((-1.0/r)-(1.0/boundary.inv_kappa_out)));
 
-            forvec[i - lowerBoundMesh] += ljforce + esforce;
-            //boundary.V[i].forvec += ljforce + esforce;
-            //boundary.V[j].forvec -= ljforce + esforce;
+            forVecMesh[i - lowerBoundMesh] += ljForce + esForce;
+        }
+        // Mesh-ion component (for mesh):
+        for (j = 0; j < counterions.size(); j++) {
+            VECTOR3D ljForce;
+            VECTOR3D esForce;
+            VECTOR3D r_vec = boundary.V[i].posvec - counterions[j].posvec;
+            double r = r_vec.GetMagnitude();
+            double r2 = r_vec.GetMagnitudeSquared();
+            double d2 = boundary.lj_length_mesh_ions * boundary.lj_length_mesh_ions;
+
+            if (r2 < dcut2 * d2) {
+                double r6 = r2 * r2 * r2;
+                double r12 = r6 * r6;
+                double d6 = d2 * d2 * d2;
+                double d12 = d6 * d6;
+                ljForce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
+            }
+
+            esForce = ((-scalefactor * boundary.V[i].q * counterions[j].q / boundary.em) *
+                       (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
+                       (r_vec ^ (1 / r2)) ^ ((-1.0 / r) - (1.0 / boundary.inv_kappa_out)));
+
+            forVecMesh[i - lowerBoundMesh] += ljForce + esForce;
+        }
+    }
+    // Ion-ion component:
+    #pragma omp parallel for schedule(dynamic) default(shared) private(i, j)
+    for (i = lowerBoundIons; i <= upperBoundIons; i++) {
+        // Ion-ion component:
+        for (j = 0; j < counterions.size(); j++) {
+            if (i == j) continue;
+            VECTOR3D ljForce;
+            VECTOR3D esForce;
+            VECTOR3D r_vec = counterions[i].posvec - counterions[j].posvec;
+            double r = r_vec.GetMagnitude();
+            double r2 = r_vec.GetMagnitudeSquared();
+            double d2 = counterions[0].diameter * counterions[0].diameter;
+
+            if (r2 < dcut2 * d2) {
+                double r6 = r2 * r2 * r2;
+                double r12 = r6 * r6;
+                double d6 = d2 * d2 * d2;
+                double d12 = d6 * d6;
+                ljForce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
+            }
+
+            esForce = ((-scalefactor * counterions[i].q * counterions[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
+                       (r_vec ^ (1/r2)) ^ ((-1.0/r)-(1.0/boundary.inv_kappa_out)));
+
+            forVecIons[i - lowerBoundIons] += ljForce + esForce;
+        }
+        // Mesh-ion component (for ions):
+        for (j = 0; j < boundary.V.size(); j++) {
+            VECTOR3D ljForce;
+            VECTOR3D esForce;
+            VECTOR3D r_vec = counterions[i].posvec - boundary.V[j].posvec;
+            double r = r_vec.GetMagnitude();
+            double r2 = r_vec.GetMagnitudeSquared();
+            double d2 = boundary.lj_length_mesh_ions * boundary.lj_length_mesh_ions;
+
+            if (r2 < dcut2 * d2) {
+                double r6 = r2 * r2 * r2;
+                double r12 = r6 * r6;
+                double d6 = d2 * d2 * d2;
+                double d12 = d6 * d6;
+                ljForce = (r_vec ^ (48 * boundary.elj * ((d12 / r12) - 0.5 * (d6 / r6)) * (1 / r2)));
+            }
+
+            esForce = ((-scalefactor * counterions[i].q * boundary.V[j].q / boundary.em) * (exp(-(1.0 / boundary.inv_kappa_out) * r)) ^
+                       (r_vec ^ (1/r2)) ^ ((-1.0/r)-(1.0/boundary.inv_kappa_out)));
+
+            forVecIons[i - lowerBoundIons] += ljForce + esForce;
         }
     }
 
-    // Update bending forces:
+    // %%% Additional mesh-only updates: %%%
+    // Initialize and update bending forces:
     for (i = 0; i < boundary.V.size(); i++)
         boundary.V[i].bforce = VECTOR3D(0,0,0);
     for (i = 0; i < boundary.E.size(); i++)
         boundary.E[i].bending_forces(&boundary);
-    //for (i = 0; i < boundary.V.size(); i++)
-    //    boundary.V[i].forvec += boundary.V[i].bforce;
     // Update stretching forces:
     for (i = 0; i < boundary.V.size(); i++)
-    {
         boundary.V[i].stretching_forces(&boundary, bucklingFlag);
-        //boundary.V[i].forvec += boundary.V[i].sforce;
-    }
     // Surface & volume tension forces (2017.09.17, 2019.08.16 NB added):
-    for (i = 0; i < boundary.V.size(); i++)
-    {   // Recalculation of negated gradients already handled above.
+    for (i = 0; i < boundary.V.size(); i++) { // Recalculation of negated gradients already handled above.
         boundary.V[i].tension_forces(&boundary);
         boundary.V[i].volume_tension_forces(&boundary);
     }
 
-    //forvec broadcasting using all gather = gather + broadcast
+    // Collect MPI forVec computations via broadcasting using (all_gather = gather + broadcast):
     if (world.size() > 1) {
-        all_gather(world, &forvec[0], forvec.size(), forvecGather);
-    } else {
+        all_gather(world, &forVecMesh[0], forVecMesh.size(), forVecMeshGather);
+        all_gather(world, &forVecIons[0], forVecIons.size(), forVecIonsGather);
+    }
+    else {
         for (i = lowerBoundMesh; i <= upperBoundMesh; i++)
-            forvecGather[i] = forvec[i - lowerBoundMesh];
+            forVecMeshGather[i] = forVecMesh[i - lowerBoundMesh];
+        for (i = lowerBoundIons; i <= upperBoundIons; i++)
+            forVecIonsGather[i] = forVecIons[i - lowerBoundMesh];
     }
 
     for (i = 0; i < boundary.V.size(); i++)
-        boundary.V[i].forvec = forvecGather[i] + boundary.V[i].bforce + boundary.V[i].sforce + boundary.V[i].TForce + boundary.V[i].VolTForce;
+        boundary.V[i].forvec = forVecMeshGather[i] + boundary.V[i].bforce + boundary.V[i].sforce + boundary.V[i].TForce + boundary.V[i].VolTForce;
 
-    forvec.clear();
-    forvecGather.clear();
+    for (i = 0; i < counterions.size(); i++)
+        counterions[i].forvec = forVecIonsGather[i];
 
-
-
-}
+    forVecMesh.clear();
+    forVecIons.clear();
+    forVecMeshGather.clear();
+    forVecIonsGather.clear();
+    }

--- a/src/newforces.h
+++ b/src/newforces.h
@@ -3,7 +3,7 @@
 
 #include "vertex.h"
 
-void force_calculation_init(INTERFACE &, const double, char bucklingFlag);	// calculate the forces
-void force_calculation(INTERFACE &, const double, char bucklingFlag);	// calculate the forces
+void force_calculation_init(INTERFACE &, vector<PARTICLE> &, const double, char bucklingFlag);	// calculate the forces
+void force_calculation(INTERFACE &, vector<PARTICLE> &, const double, char bucklingFlag);	// calculate the forces
 
 #endif 

--- a/src/particle.h
+++ b/src/particle.h
@@ -65,9 +65,8 @@ public:
     }
 
     // update position of the particle
-    void update_position(double dt)
-    {
-        posvec = ( posvec + (velvec ^ dt) );
+    void update_real_position(double dt) {
+        posvec = (posvec + (velvec ^ dt));
         return;
     }
 
@@ -78,9 +77,9 @@ public:
         return;
     }
 
-    void new_update_velocity(double dt, THERMOSTAT main_bath, long double expfac)
+    void update_real_velocity(double dt, THERMOSTAT ion_bath, long double expfac)
     {
-        velvec = ( ( velvec ^ (expfac)  ) + ( forvec ^ (0.5 * dt * sqrt(expfac)) ) );
+        velvec = ((velvec ^ (expfac)) + (forvec ^ (0.5 * dt * sqrt(expfac))));
         return;
     }
 


### PR DESCRIPTION
The ions now move as forces are computed and the ions have been added to the Verlet propagation.  The forces are OMP/MPI parallelized and the OMP has been tested, will test the MPI.

On LJ interactions, the LJ mesh-mesh interactions are as they were before.  The functional form is the same for mesh-ion interactions, but with an LJ-length (sigma) set to the average of the mesh point diameter (set by the average edge length) and the ion diameter ((d_m + d_ion) / 2) and the cut-off is 2^(1/6) times this length.  In a 250K step effectively equilibrated run, this prevents them from penetrating the NP when it is rigid.  This was tested using the following:

time .\np_shape_lab -R 10 -q 600 -c 0.005 -t 1 -v 1 -b 1000 -s 100000 -S 250000 -D 4 -C 1 -d 0.00025 -F n -I y

This has not been added as an example simulation yet because I need to add:

- A bounding box for the ions (some just drift to infinity).
- An ion thermostat.
- Ensure the randomness flag ("-F") still works to eliminate machine-to-machine variation.

All example files without ions still run well.  The standard disc control is shown below:

<img width="858" alt="NoChange" src="https://user-images.githubusercontent.com/38959843/68235711-b87da300-ffd1-11e9-8484-e8f570dced76.PNG">